### PR TITLE
add x-forwarded-for translation support

### DIFF
--- a/README
+++ b/README
@@ -58,6 +58,16 @@ Default: shared_memory
 Context: http
 Description: specifies to where the iplocation DB file will be loaded.
 
+Syntax:  ip2location_proxy cidr|address
+Default: none
+Context: http
+Description: sets a list of proxies to translate x-forwarded-for headers for
+
+Syntax:  ip2location_proxy_recursive on|off
+Default: off
+Context: http
+Description: enables recursive search in the x-forwarded-for address list
+
 
 Variables
 ---------


### PR DESCRIPTION
this pull request adds support for using the ip provided in `x-forwarded-for` http headers, similar to the geoip2 module.